### PR TITLE
Update iteration 2 instruction and tests for AI feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,12 @@ Implement the function `maxOfTwoNumbers` that takes two numbers as arguments and
 ### Iteration 2 | Find the Longest Word
 
 Implement the function `findLongestWord` that takes as an argument an array of words and returns the longest one. If there are 2 with the same length, it should return the first occurrence.
+<br>
 
-You can use the following array to test your solution:
+The function should return `null` if an empty array is passed as an argument.
+
+
+You can use the following array to test your solution
 
 ```javascript
 const words = ["mystery", "brother", "aviator", "crocodile", "pearl", "orchard", "crackpot"];

--- a/tests/functions-and-arrays.spec.js
+++ b/tests/functions-and-arrays.spec.js
@@ -114,7 +114,7 @@ describe("Iteration 5 | Find Elements", () => {
       expect(typeof doesWordExist).toBe("function");
     });
 
-    it("should return null if receives an empty array when called", () => {
+    it("should return null when called with an empty array", () => {
       expect(doesWordExist([])).toBeNull();
     });
 

--- a/tests/functions-and-arrays.spec.js
+++ b/tests/functions-and-arrays.spec.js
@@ -49,8 +49,8 @@ describe("Iteration 2 | Find the Longest Word", () => {
       }
     });
 
-    it("should return 0 when called with an empty array", () => {
-      expect(findLongestWord([])).toBe(0);
+    it("should return null when called with an empty array", () => {
+      expect(findLongestWord([])).toBeNull();
     });
 
     it("should return the first word when called with a single-word array", () => {
@@ -115,7 +115,7 @@ describe("Iteration 5 | Find Elements", () => {
     });
 
     it("should return null if receives an empty array when called", () => {
-      expect(doesWordExist([])).toBe(null);
+      expect(doesWordExist([])).toBeNull();
     });
 
     it("should return false if the word we are looking for is not in the array", () => {


### PR DESCRIPTION
This pull request addresses the issue with AI feedback giving a wrong answer for iteration 2. In particular, the model is inferring the answer from the similar instructions in iteration 5.

The temporary fix for the issue is to update the lab iteration 2,  to be the same as in iteration 5 and instead ask student to return null if an empty array is passed as an argument. This is just a quick fix until this is rectified on the model and the prompt.